### PR TITLE
Add option to preserve headers in `data` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ class RtpSession {
             time_stamp: 160,
         }
 
+        this._preserve_headers = opts.preserve_headers || false
+
         //console.log(this._info)
 
         var version = 2
@@ -54,7 +56,7 @@ class RtpSession {
 
             // TODO: must check if message is really an RTP packet
 
-            var data = msg.slice(12) // assume 12 bytes header for now
+            var data = this._preserve_headers ? msg : msg.slice(12) // assume 12 bytes header for now
             this._socket.emit('data', data) 
         })
 


### PR DESCRIPTION
In order to allow an app to proxy RTP packets to another receiver, it's useful to be able to preserve the headers.

For example, this allows an application to pair your MRCP tools with Asterisk's external media tools to play audio received via the MRCP client.

I'll open a follow up MR against the `sip-mrcp` repo to allow passing this option through. (Edit; [here](https://github.com/MayamaTakeshi/sip-mrcp/pull/3))